### PR TITLE
fix dependabot directory for terraform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -9,9 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
+  
   - package-ecosystem: "terraform"
-    directory: "/tests/terraform/infra-build"
+    directory: "/tests/alz-vnet"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
Dependabot has not been running for this module repo and this PR is to fix the directory for the Terraform package-ecosystem in dependabot.yml to `/tests/alz-vnet`.

The original directory `/tests/terraform/infra-build` appears to be a copy/paste from the VM module.

Also fixed the broken link for GitHub docs URL.