### PR TITLE
renamed the deprecated attribute and removed tags

### DIFF
--- a/modules/alz-vnet/main.tf
+++ b/modules/alz-vnet/main.tf
@@ -9,12 +9,12 @@ resource "azurerm_virtual_network" "vnet" {
 
 # Deploy hub subnets within virtual network
 resource "azurerm_subnet" "subnet" {
-  for_each                                  = var.subnet
-  name                                      = each.key
-  resource_group_name                       = var.resource_group_name
-  address_prefixes                          = each.value.address_prefixes
-  virtual_network_name                      = azurerm_virtual_network.vnet.name
-  service_endpoints                         = each.value.service_endpoints
+  for_each                          = var.subnet
+  name                              = each.key
+  resource_group_name               = var.resource_group_name
+  address_prefixes                  = each.value.address_prefixes
+  virtual_network_name              = azurerm_virtual_network.vnet.name
+  service_endpoints                 = each.value.service_endpoints
   private_endpoint_network_policies = each.key != "GatewaySubnet" ? each.value.private_endpoint_network_policies : "Enabled"
   dynamic "delegation" {
     for_each = each.value.delegations

--- a/modules/alz-vnet/main.tf
+++ b/modules/alz-vnet/main.tf
@@ -15,7 +15,7 @@ resource "azurerm_subnet" "subnet" {
   address_prefixes                          = each.value.address_prefixes
   virtual_network_name                      = azurerm_virtual_network.vnet.name
   service_endpoints                         = each.value.service_endpoints
-  private_endpoint_network_policies = each.key != "GatewaySubnet" ? each.value.private_endpoint_network_policies : true
+  private_endpoint_network_policies = each.key != "GatewaySubnet" ? each.value.private_endpoint_network_policies : "Enabled"
   dynamic "delegation" {
     for_each = each.value.delegations
     content {

--- a/modules/alz-vnet/main.tf
+++ b/modules/alz-vnet/main.tf
@@ -5,7 +5,6 @@ resource "azurerm_virtual_network" "vnet" {
   location            = var.location
   address_space       = var.vnet_address_space
   dns_servers         = var.dns_servers
-  tags                = var.tags
 }
 
 # Deploy hub subnets within virtual network
@@ -16,7 +15,7 @@ resource "azurerm_subnet" "subnet" {
   address_prefixes                          = each.value.address_prefixes
   virtual_network_name                      = azurerm_virtual_network.vnet.name
   service_endpoints                         = each.value.service_endpoints
-  private_endpoint_network_policies_enabled = each.key != "GatewaySubnet" ? each.value.private_endpoint_network_policies_enabled : true
+  private_endpoint_network_policies = each.key != "GatewaySubnet" ? each.value.private_endpoint_network_policies : true
   dynamic "delegation" {
     for_each = each.value.delegations
     content {

--- a/modules/alz-vnet/variables.tf
+++ b/modules/alz-vnet/variables.tf
@@ -21,7 +21,7 @@ variable "vnet_address_space" {
 variable "subnet" {
   type = map(object({
     address_prefixes                          = list(string)
-    private_endpoint_network_policies_enabled = bool
+    private_endpoint_network_policies = bool
     service_endpoints                         = list(string)
     delegations = list(object({
       name = string
@@ -39,13 +39,9 @@ variable "dns_servers" {
   default     = []
 }
 
-variable "private_endpoint_network_policies_enabled" {
+variable "private_endpoint_network_policies" {
   type        = bool
   default     = false
   description = "This setting is needed to allow private endpoints. If the subnet will get a private endpoint this must be set to true"
 }
 
-variable "tags" {
-  type        = map(any)
-  description = "A map of tags applied to the VNET."
-}

--- a/modules/alz-vnet/variables.tf
+++ b/modules/alz-vnet/variables.tf
@@ -20,9 +20,9 @@ variable "vnet_address_space" {
 
 variable "subnet" {
   type = map(object({
-    address_prefixes                          = list(string)
+    address_prefixes                  = list(string)
     private_endpoint_network_policies = string
-    service_endpoints                         = list(string)
+    service_endpoints                 = list(string)
     delegations = list(object({
       name = string
       service_delegation = list(object({

--- a/modules/alz-vnet/variables.tf
+++ b/modules/alz-vnet/variables.tf
@@ -21,7 +21,7 @@ variable "vnet_address_space" {
 variable "subnet" {
   type = map(object({
     address_prefixes                          = list(string)
-    private_endpoint_network_policies = bool
+    private_endpoint_network_policies = string
     service_endpoints                         = list(string)
     delegations = list(object({
       name = string
@@ -40,8 +40,8 @@ variable "dns_servers" {
 }
 
 variable "private_endpoint_network_policies" {
-  type        = bool
-  default     = false
-  description = "This setting is needed to allow private endpoints. If the subnet will get a private endpoint this must be set to true"
+  type        = string
+  default     = "Disabled"
+  description = "This setting is needed to allow private endpoints. If the subnet will get a private endpoint this must be set to Enabled"
 }
 

--- a/tests/alz-vnet/main.tf
+++ b/tests/alz-vnet/main.tf
@@ -7,7 +7,6 @@ locals {
 resource "azurerm_resource_group" "rg" {
   name     = "rg-pr-alzvnet-001"
   location = "UK South"
-  tags     = var.tags
 }
 
 
@@ -17,7 +16,6 @@ module "vnet" {
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
   subnet              = var.subnet
-  tags                = var.tags
   vnet_name           = "vnet-pr-alz-vnet-001"
   vnet_address_space  = var.vnet_address_space
 }

--- a/tests/alz-vnet/variables.tf
+++ b/tests/alz-vnet/variables.tf
@@ -24,7 +24,7 @@ variable "subnet" {
 
   type = map(object({
     address_prefixes                          = list(string)
-    private_endpoint_network_policies_enabled = bool
+    private_endpoint_network_policies = bool
     service_endpoints                         = list(string)
     delegations = list(object({
       name = string
@@ -37,13 +37,13 @@ variable "subnet" {
   default = {
     "testsubnet1" = {
       address_prefixes                          = ["192.168.1.0/28"]
-      private_endpoint_network_policies_enabled = false
+      private_endpoint_network_policies = false
       service_endpoints                         = ["Microsoft.Storage", "Microsoft.KeyVault"]
       delegations                               = []
     },
     "testsubnet2" = {
       address_prefixes                          = ["172.16.1.0/28"]
-      private_endpoint_network_policies_enabled = false
+      private_endpoint_network_policies = false
       delegations = [{
         name = "delegation"
         service_delegation = [{
@@ -55,21 +55,15 @@ variable "subnet" {
     },
     "testsubnet3" = {
       address_prefixes                          = ["172.16.1.32/28"]
-      private_endpoint_network_policies_enabled = false
+      private_endpoint_network_policies = false
       delegations                               = []
       service_endpoints                         = []
     },
     "GatewaySubnet" = {
       address_prefixes                          = ["192.168.1.64/26"]
-      private_endpoint_network_policies_enabled = false
+      private_endpoint_network_policies = false
       delegations                               = []
       service_endpoints                         = []
     },
   }
-}
-
-variable "tags" {
-  type        = map(string)
-  default     = {}
-  description = "Generic tags for supported resources"
 }

--- a/tests/alz-vnet/variables.tf
+++ b/tests/alz-vnet/variables.tf
@@ -24,7 +24,7 @@ variable "subnet" {
 
   type = map(object({
     address_prefixes                          = list(string)
-    private_endpoint_network_policies = bool
+    private_endpoint_network_policies = string
     service_endpoints                         = list(string)
     delegations = list(object({
       name = string
@@ -37,13 +37,13 @@ variable "subnet" {
   default = {
     "testsubnet1" = {
       address_prefixes                          = ["192.168.1.0/28"]
-      private_endpoint_network_policies = false
+      private_endpoint_network_policies = "Disabled"
       service_endpoints                         = ["Microsoft.Storage", "Microsoft.KeyVault"]
       delegations                               = []
     },
     "testsubnet2" = {
       address_prefixes                          = ["172.16.1.0/28"]
-      private_endpoint_network_policies = false
+      private_endpoint_network_policies = "Disabled"
       delegations = [{
         name = "delegation"
         service_delegation = [{
@@ -55,13 +55,13 @@ variable "subnet" {
     },
     "testsubnet3" = {
       address_prefixes                          = ["172.16.1.32/28"]
-      private_endpoint_network_policies = false
+      private_endpoint_network_policies = "Disabled"
       delegations                               = []
       service_endpoints                         = []
     },
     "GatewaySubnet" = {
       address_prefixes                          = ["192.168.1.64/26"]
-      private_endpoint_network_policies = false
+      private_endpoint_network_policies = "Disabled"
       delegations                               = []
       service_endpoints                         = []
     },

--- a/tests/alz-vnet/variables.tf
+++ b/tests/alz-vnet/variables.tf
@@ -23,9 +23,9 @@ variable "subnet" {
   description = "This variable contains the subnet details"
 
   type = map(object({
-    address_prefixes                          = list(string)
+    address_prefixes                  = list(string)
     private_endpoint_network_policies = string
-    service_endpoints                         = list(string)
+    service_endpoints                 = list(string)
     delegations = list(object({
       name = string
       service_delegation = list(object({
@@ -36,13 +36,13 @@ variable "subnet" {
 
   default = {
     "testsubnet1" = {
-      address_prefixes                          = ["192.168.1.0/28"]
+      address_prefixes                  = ["192.168.1.0/28"]
       private_endpoint_network_policies = "Disabled"
-      service_endpoints                         = ["Microsoft.Storage", "Microsoft.KeyVault"]
-      delegations                               = []
+      service_endpoints                 = ["Microsoft.Storage", "Microsoft.KeyVault"]
+      delegations                       = []
     },
     "testsubnet2" = {
-      address_prefixes                          = ["172.16.1.0/28"]
+      address_prefixes                  = ["172.16.1.0/28"]
       private_endpoint_network_policies = "Disabled"
       delegations = [{
         name = "delegation"
@@ -54,16 +54,16 @@ variable "subnet" {
       service_endpoints = []
     },
     "testsubnet3" = {
-      address_prefixes                          = ["172.16.1.32/28"]
+      address_prefixes                  = ["172.16.1.32/28"]
       private_endpoint_network_policies = "Disabled"
-      delegations                               = []
-      service_endpoints                         = []
+      delegations                       = []
+      service_endpoints                 = []
     },
     "GatewaySubnet" = {
-      address_prefixes                          = ["192.168.1.64/26"]
+      address_prefixes                  = ["192.168.1.64/26"]
       private_endpoint_network_policies = "Disabled"
-      delegations                               = []
-      service_endpoints                         = []
+      delegations                       = []
+      service_endpoints                 = []
     },
   }
 }


### PR DESCRIPTION
I need to fix this repo first before i can run PRs of the landing zone main repo.
in this PR i have renamed the deprecated attribute for private network endpoint policies and removed tags.
It is not just renaming but the type is also changed from bool to string with the default value of "Disabled". This is a result of terraform changing this attribute name and type.
Tags are removed as this module is not applying tags on the resource group. The resource group is created outside of this module and we have decided not to apply tags directly on resources in this case the vnet and subnet resource.