### PR TITLE
lifecycle ignore for tags

### DIFF
--- a/modules/alz-vnet/main.tf
+++ b/modules/alz-vnet/main.tf
@@ -5,6 +5,11 @@ resource "azurerm_virtual_network" "vnet" {
   location            = var.location
   address_space       = var.vnet_address_space
   dns_servers         = var.dns_servers
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 }
 
 # Deploy hub subnets within virtual network
@@ -30,5 +35,10 @@ resource "azurerm_subnet" "subnet" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 }
 

--- a/modules/alz-vnet/main.tf
+++ b/modules/alz-vnet/main.tf
@@ -34,11 +34,5 @@ resource "azurerm_subnet" "subnet" {
       }
     }
   }
-
-  lifecycle {
-    ignore_changes = [
-      tags,
-    ]
-  }
 }
 


### PR DESCRIPTION
using the lifecycle block with the ignore_changes argument in the resource definition. This will instruct Terraform to ignore the tags being applied through Azure policy inheritance, preventing Terraform from attempting to overwrite or remove these tags.